### PR TITLE
Supports Apple Silicon

### DIFF
--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -233,7 +233,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {
@@ -249,7 +249,10 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build"
+          "run" : "cmake -S . -B build",
+          "env" : {
+            "CMAKE_OSX_ARCHITECTURES":"x86_64;arm64"
+          }
         },
         {
           "name" : "Build project",
@@ -282,7 +285,7 @@
       "steps" : [
         {
           "name" : "Download all artifacts",
-          "uses" : "actions/download-artifact@v3"
+          "uses" : "actions/download-artifact@v4"
         },
         {
           "name" : "Prepare artifacts for release",


### PR DESCRIPTION
The problems that occur are the same as those of [KAGParser.](https://github.com/krkrsdl2/KAGParser/pull/1)

<img width="769" alt="image" src="https://github.com/krkrsdl2/wuvorbis/assets/58556570/3b341f96-f644-4045-bb5a-61c239cb9903">

This change let CI to create universal binary for Apple Silicon. 

The following is a confirmation of it working.

<img width="798" alt="image" src="https://github.com/krkrsdl2/wuvorbis/assets/58556570/fcb261bf-2c9a-42f4-a7a0-06301e486ca9">
